### PR TITLE
Add a widget for running element content through an external processor

### DIFF
--- a/src/builtin_widgets.ml
+++ b/src/builtin_widgets.ml
@@ -7,5 +7,6 @@ let widgets = [
   ("title", Title_widget.set_title);
   ("breadcrumbs", Breadcrumbs_widget.breadcrumbs);
   ("footnotes", Footnotes_widget.footnotes);
-  ("toc", Toc_widget.toc)
+  ("toc", Toc_widget.toc);
+  ("replace_text", Inclusion_widgets.replace_text)
 ]

--- a/src/builtin_widgets.ml
+++ b/src/builtin_widgets.ml
@@ -8,5 +8,5 @@ let widgets = [
   ("breadcrumbs", Breadcrumbs_widget.breadcrumbs);
   ("footnotes", Footnotes_widget.footnotes);
   ("toc", Toc_widget.toc);
-  ("replace_text", Inclusion_widgets.replace_text)
+  ("preprocess_element", Inclusion_widgets.preprocess_element)
 ]

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -19,8 +19,10 @@ let get_program_output ?(input=None) command env_array =
     | None -> ()
     | Some i ->
       let () = Logs.debug @@ fun m -> m "Data sent to program \"%s\": %s" command i in
-      Printf.fprintf std_in "%s\n%!" i
+      Printf.fprintf std_in "%s" i
   in
+  (* close stdin to flag end of input *)
+  let () = close_out std_in in
   let output = Soup.read_channel std_out in
   let err = Soup.read_channel std_err in
   let res = Unix.close_process_full (std_out, std_in, std_err) in

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -132,9 +132,13 @@ let child_nodes e =
 
 (** Retrieves the innerHTML of an element --
     a string representation of its children *)
-let inner_html e =
+let inner_html ?(escape_html=true) e =
   let children = child_nodes e in
-  Soup.to_string children
+  if escape_html then Soup.to_string children
+  else
+      let escape_text = fun (x:string) -> x in
+      let escape_attribute = fun (x:string) -> x in
+      children |> Soup.signals |> (fun s -> Markup.write_html ~escape_text ~escape_attribute s) |> Markup.to_string
 
 (** Appends a child if child rather than None is given *)
 let append_child container child =


### PR DESCRIPTION
Firstly. Thanks for soupault! 

This patch adds a built-in widget called `replace_text`. The widget reads the `leaf_text` of an element that matches the `selector`, calls the external program specified by `command` using the `leaf_text` as `stdin`. Finally it reads the `stdout` of the application and replaces the content of the node with the result of the command.

For example:
```
[widgets.hilight-bash]
  widget = "replace_text"
  selector = ".hilight-bash"
  command = "highlight -S bash -f"
```
Would replace the text in elements with the class .hilight-bash and replace it with the parsed output of the highlight command.


I've successfully used it on my not yet published blog. Mainly for code highlighting and graphs (dot) but it should work with a number of external programs (for example latex, or pandoc) and it should make it easy to add additional functionality to soupault as an alternative to the lua plugins. 

A few comments:

* Using `Soup.leaf_text` is not really what I want but I couldn't find anything better from the Soup library. Ideally I would like to read all the content of the node as "verbatim" text.
* This widget applies to all nodes found in a file. I.e it is using `Soup.select` instead of `Soup.select_one` which seems to be used elsewhere.
* In `utils.ml` I'm closing stdin to tell the external application that input is done. This also means that the extra `\n` should no longer be needed, but it is the only? change that may affect other functionality.
* My `replace_text` function is not monoadic and differs in style from other functions.

I am happy to work more on this if you think it is a good idea. If not, no worries.

Cheers!
