### PR TITLE
Fix 'title_widget' when the selected node contains HTML tags

### DIFF
--- a/src/title_widget.ml
+++ b/src/title_widget.ml
@@ -27,11 +27,11 @@ let set_title _ config soup =
     Ok ()
   | Some title_node ->
     let title_string =
-      Utils.select_any_of selectors soup >>= Soup.leaf_text |> make_title_string default_title prepend append in
+      Utils.select_any_of selectors soup >>= Utils.get_element_text
+        |> make_title_string default_title prepend append in
     (* XXX: Both Soup.create_text and Soup.create_element ~inner_text:... escape special characters
        instead of expanding entities, so "&mdash;" becomes "&amp;mdash", which is not what we want.
        Soup.parse expands them, which is why it's used here *)
     let new_title_node = Printf.sprintf "<title>%s</title>" title_string |> Soup.parse in
     let () = Soup.replace title_node new_title_node in
     Ok ()
-


### PR DESCRIPTION
Note: I tried to send an email to the soupault mailing list, but for some reason failed. I don’t have a lot of time for debugging this, so I create a PR instead.

With 'Soup.leaf_text', the function returns 'None' when the node
contains more than one child.  However, there are legitimate
situations where we could want to do such a thing.

For instance, consider the following title:

    <h1><code>wc</code> in language Y</h1>

In soupault.1.8.0, this title results in the use of the default title.
With this patch, the rendered titles is

    <title>wc in language Y</title>