### PR TITLE
Fix 'title_widget' inserting unwanted spaces sometimes

### DIFF
--- a/src/utils.ml
+++ b/src/utils.ml
@@ -115,8 +115,7 @@ let get_element_text e =
   | [] -> None
   | _ ->
     (* "Normalize" the whitespace *)
-    let texts = List.map String.trim texts in
-    let text = String.concat " " texts |> String.trim in
+    let text = String.concat "" texts |> String.trim in
     if text = "" then None else Some text
 
 let rec select_any_of selectors soup =


### PR DESCRIPTION
Consider the following title

    <h1><code>foo</code>, bar</h1>

Before this patch, the rendered title would have been:

    <title>foo , bar</title>

After this patch, the unwanted space is no longer inserted.
Therefore, we fix dmbaturin/soupault#13.