### PR TITLE
HTML entities &amp; tags

### DIFF
--- a/sample-site/site/about.inc
+++ b/sample-site/site/about.inc
@@ -1,9 +1,12 @@
 <h1>About me</h1>
 <p>
-I have graduated from the Miskatonic Institute of Technology where I majored in computer science
-and minored in applied mythology. My thesis was &ldquo;Zipf's law and the Necronomicon&rdquo;
+I graduated from the Miskatonic Institute of Technology where I majored in
+computer science and minored in applied mythology. My thesis was
+&ldquo;Zipf&apos;s law &amp; the Necronomicon&rdquo;.
 </p>
 <p>
-I'm now working on obscenity-tolerant data transmission protocols at the Cosmodemonic Telegraph Company.
+I&apos;m now working on obscenity-tolerant data transmission protocols,
+<abbr title="obscenity-tolerant data transmission protocols">OTDTP</abbr>,
+at the Cosmodemonic Telegraph Company.
 </p>
 

--- a/sample-site/site/index.inc
+++ b/sample-site/site/index.inc
@@ -1,6 +1,6 @@
 <h1>Welcome to my homepage!</h1>
 <p>
-I'm J. Random Hacker. I like hacking various things.
+I&apos;m J. Random Hacker. I like hacking various things.
 </p>
 <p>
 On this page you can find various information about me.

--- a/sample-site/templates/main.html
+++ b/sample-site/templates/main.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <!-- NB: <title/> is invalid and would break parsing -->
     <title> </title>
@@ -7,8 +7,8 @@
     <div id="breadcrumbs"> </div>
     <div id="content"> </div>
     <div>
-      <p>Generated on <span id="generated-on" /> </p>
-      <p>Last modified: <span id="last-modified" /> </p>
+      <p>Generated on <time id="generated-on" /> </p>
+      <p>Last modified: <time id="last-modified" /> </p>
     </div>
     <div id="footer"></div>
   </body>

--- a/src/project_init.ml
+++ b/src/project_init.ml
@@ -19,7 +19,7 @@ let default_template = "
 
 let default_page = "
 <h1>Welcome!</h1>
-<p>Welcome to my homepage. It's under construction.</p>
+<p>Welcome to my homepage. It&apos;s under construction.</p>
 "
 
 (* This part contains the default settings and it's used in more than one place in the code *)


### PR DESCRIPTION
- ticks, “'”, → apostrophe entity, `&apos;`
- time `<span>`s → time `<time>`s (though missing `datatime` attribute,
this is still more semantic)
- `lang` attribute for HTML
- thesis title uses `&amp;` + missing period.
- `<abbr>` tag for OTDTP profession to add legitimacy